### PR TITLE
Handle tags creation during paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ import InputTag from 'vue-input-tag'
 | ---:| --- | ---| --- |
 | tags | Array | [] | Tags to be render in the input |
 | placeholder | String | "" | Placeholder to be shown when no tags |
+| on-paste-delimiter | String | "" | During pasting, this delimiter is used to create multiple tags |
 | read-only | Boolean | false | Set input to readonly |
 | on-change | Function | undefined | Callback to get the tags when there is a change |
 | validate | String | "" | Apply certain validator for user input. Choose from `email`, `url`, `text`, `digits` or `isodate`

--- a/docs/App.vue
+++ b/docs/App.vue
@@ -10,6 +10,7 @@
       return {
         readOnly: false,
         placeholder: 'Add Tag',
+        onPasteSeparator: '',
         tags: ['Jerry', 'Kramer', 'Elaine', 'George'],
         htmlCode: '',
         validate: ''
@@ -24,6 +25,7 @@
       getPreviewHTML () {
         let html = '<input-tag'
         html += this.placeholder ? ` placeholder="${this.placeholder}"` : ''
+        html += this.onPasteSeparator ? ` on-paste-separator="${this.onPasteSeparator}"` : ''
         html += this.tags ? ' :tags="tags"' : ''
         html += this.readOnly ? ' :read-only="true"' : ''
         html += this.validate ? ` validate="${this.validate}"` : ''
@@ -68,6 +70,10 @@
           input(v-model='placeholder' type='text')
 
         .form-group
+          p.label onPasteSeparator:
+          input(v-model='onPasteSeparator' type='text')
+
+        .form-group
           p.label readOnly:
           input(v-model='readOnly' type='checkbox')
 
@@ -89,6 +95,7 @@
           :on-change='newTag',
           :tags='tags',
           :placeholder='placeholder',
+          :on-paste-separator='onPasteSeparator',
           :read-only='readOnly',
           :validate='validate'
         )
@@ -111,7 +118,7 @@
     p.label {
       display: inline-block;
       margin-right: 1rem;
-      width: 100px;
+      width: 140px;
     }
     input {
       padding: 5px;

--- a/src/InputTag.vue
+++ b/src/InputTag.vue
@@ -58,6 +58,10 @@
       validate: {
         type: String,
         default: ''
+      },
+      onPasteSeparator: {
+        type: String,
+        default: null
       }
     },
 
@@ -74,6 +78,14 @@
       },
 
       addNew (tag) {
+        if (this.onPasteSeparator && tag.indexOf(this.onPasteSeparator) !== -1) {
+          tag.split(this.onPasteSeparator)
+            .map(t => t.trim())
+            .map(this.addNew)
+
+          return
+        }
+
         if (tag && this.tags.indexOf(tag) === -1 && this.validateIfNeeded(tag)) {
           this.tags.push(tag)
           this.tagChange()


### PR DESCRIPTION
To enable this feature, you should provide `on-paste-separator` property, e.g.:
```html
<input-tag on-paste-separator=";" ...></input-tag>
```
Then you can paste a string (e.g.: `apple;pear;banana;apple`), and 3 new tags will be created (3 tags instead of 4 because we shouldn't allow tag duplication): 
- `apple`
- `pear`
- `banana`

---

Also, a good combo is to use props `validate`:
 ```html
<input-tag on-paste-separator=";" validate="email" ...></input-tag>
```

Then when you will paste a string (e.g.: `hugo@yproximite.com;not a valid email;foo@bar.com`, 2 new tags will be created:
- `hugo@yproximite.com`
- `foo@bar.com`